### PR TITLE
Fix compilation on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ To build natively on Windows using MSVC, you will also need: git, ninja and cmak
 
 If you just wish to build libaptdec on Windows, libpng and libsndfile aren't needed.
 
+## Building for Android
+
+Requires at least API 23
+
 ## Further Reading
 
 [User's Guide for Building and Operating

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <complex.h>
 
 #include "apt.h"
 #include "filter.h"
@@ -90,7 +91,6 @@ static int getamp(float *ampbuff, int count, apt_getsamples_t getsamples, void *
     static int nin = 0;
 
     for (int n = 0; n < count; n++) {
-        float I2, Q;
 
         // Get some more samples when needed
         if (nin < HILBERT_FILTER_SIZE * 2 + 2) {


### PR DESCRIPTION
Include complex.h needed on Android. 
Remove unused variables in dsp.c.
Note that building on Android requires API 23.

(aptdec is included in SDRangel on Android: https://play.google.com/store/apps/details?id=org.sdrangel&hl=en_US)
